### PR TITLE
Force webpack to bind to localhost

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "webpack",
     "electron": "electron .",
-    "dev-server":"webpack-dev-server",
+    "dev-server": "webpack-dev-server --host 127.0.0.1",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",


### PR DESCRIPTION
Force webpack to use a local ip since apparently you can't trust DNS servers to return the right ip for localhost... I can't believe I even have to do this.