### PR TITLE
Helpful webpack not running error message

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -8,4 +8,5 @@ const jsx = (
 );
 
 const appRoot = document.getElementById('app');
+document.getElementById('no-webpack').style.display = 'none'; // hide the webpack error if webpack is running
 ReactDOM.render(jsx,appRoot);

--- a/src/index.html
+++ b/src/index.html
@@ -8,6 +8,7 @@
     </head>
     <body>
         <div id="app"></div>
+        <div id="no-webpack">Webpack does not seem to be running. Run 'npm run dev-server' in a new terminal window to start it</div>
         <!-- For final build -->
         <!-- <script src="./build/bundle.js"></script> -->
         <!-- For hot reload -->


### PR DESCRIPTION
Show that webpack isn't running if dev forgot to run `npm run dev-server` and what to do to fix it. Auto removes the error once webpack is running.


Very likely a very crude solution... but it works.